### PR TITLE
stop trying to share version::

### DIFF
--- a/lib/Module/Extract/VERSION.pm
+++ b/lib/Module/Extract/VERSION.pm
@@ -130,8 +130,6 @@ sub _eval_version {
 	local $^W = 0;
 
 	my $s = Safe->new;
-	$s->share_from('main', ['*version::']);
-	$s->share_from('version', ['&qv']);
 	if (defined $Devel::Cover::VERSION) {
 		$s->share_from('main', ['&Devel::Cover::use_file']);
 	}


### PR DESCRIPTION
All of the appropriate version symbols are shared with Safe compartments by default in perl 5.10 and newer. Sharing the version glob rather than individual symbols can actually break in some cases.